### PR TITLE
Remove ruby dependency

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -107,7 +107,6 @@ module.exports = function (grunt) {
     // Compile Sass to CSS without Ruby
     sass: {
         options: {
-            sourceMap: true,
             includePaths: ['<%= yeoman.app %>/bower_components']
         },
         dist: {

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -104,28 +104,21 @@ module.exports = function (grunt) {
       }
     },
 
-    // Compiles Sass to CSS and generates necessary files if requested
-    compass: {
-      options: {
-        sassDir: '<%= yeoman.app %>/styles',
-        cssDir: '.tmp/styles',
-        generatedImagesDir: '.tmp/images/generated',
-        imagesDir: '<%= yeoman.app %>/images',
-        javascriptsDir: '<%= yeoman.app %>/scripts',
-        fontsDir: '<%= yeoman.app %>/styles/fonts',
-        importPath: '<%= yeoman.app %>/bower_components',
-        httpImagesPath: '/images',
-        httpGeneratedImagesPath: '/images/generated',
-        httpFontsPath: '/styles/fonts',
-        relativeAssets: false,
-        assetCacheBuster: false,
-        raw: 'Sass::Script::Number.precision = 10\n'
-      },
-      dist: {
+    // Compile Sass to CSS without Ruby
+    sass: {
         options: {
-          generatedImagesDir: '<%= yeoman.dist %>/images/generated'
+            sourceMap: true,
+            includePaths: ['<%= yeoman.app %>/bower_components']
+        },
+        dist: {
+            files: [{
+              expand: true,
+              cwd: '<%= yeoman.app %>/styles/',
+              src: '**/*.scss',
+              dest: '.tmp/styles/',
+              ext: '.css'
+            }]
         }
-      }
     },
 
     // Renames files for browser caching purposes
@@ -162,7 +155,7 @@ module.exports = function (grunt) {
     // Performs rewrites based on filerev and the useminPrepare configuration
     usemin: {
       html: ['<%= yeoman.dist %>/{,*/}*.html'],
-      css: ['<%= yeoman.dist %>/styles/{,*/}*.css'],
+      css: ['<%= yeoman.dist %>/styles/**/*.css'],
       options: {
         assetsDirs: ['<%= yeoman.dist %>','<%= yeoman.dist %>/images']
       }
@@ -285,7 +278,7 @@ module.exports = function (grunt) {
     'wiredep',
     'injector',
     'useminPrepare',
-    'compass:dist',
+    'sass:dist',
     'imagemin',
     'autoprefixer',
     'concat',

--- a/README.md
+++ b/README.md
@@ -14,10 +14,6 @@ User interface for Ludwig, the collaborative testing tool
 Usage
 -----
 
-### Dependencies
-
-You will need [`gem`](https://rubygems.org/pages/download) to install Ruby dependencies.
-
 ### Build
 
 Installing this package through NPM (example: adding it as dependency) will automatically build assets.

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "grunt-bower-task": "^0.4.0",
     "grunt-concurrent": "1.0.0",
     "grunt-contrib-clean": "0.6.0",
-    "grunt-contrib-compass": "1.0.1",
     "grunt-contrib-concat": "0.5.0",
     "grunt-contrib-copy": "0.7.0",
     "grunt-contrib-cssmin": "0.11.0",
@@ -33,6 +32,7 @@
     "grunt-newer": "1.1.0",
     "grunt-ng-annotate": "0.9.2",
     "grunt-processhtml": "^0.3.7",
+    "grunt-sass": "^0.18.1",
     "grunt-usemin": "3.0.0",
     "grunt-wiredep": "2.0.0",
     "jshint-stylish": "1.0.0",
@@ -44,7 +44,6 @@
     "node": ">=0.10.0"
   },
   "scripts": {
-    "preinstall": "gem install --no-rdoc --no-ri sass compass",
     "postinstall": "node -e \"require('grunt').tasks(['build'])\"",
     "test": "node -e \"require('grunt').tasks(['jshint', 'build'])\""
   }


### PR DESCRIPTION
**Opened just for easy action once question in #3 is answered, should not be merged before.**

As explained in #3:

> So, it looks like we'll have to package compiled dependencies ourselves in a prepublish, which is not necessarily a bad thing.
> However, the question is: if we don't delegate to users the responsibilty to compile, we can take it on ourselves to install gems properly. Since moving to grunt-sass makes us lose Compass features, do we still want to do the replacement?