### PR TITLE
Bump to v1.0.1 (fix bad publication)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ludwig-ui",
   "description": "Web GUI for Ludwig, the collaborative testing tool",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "license": "AGPL-3.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Assets were missing in version 1.0.0.
A new version has been published and 1.0.0 is now deprecated.

To investigate.