### PR TITLE
Allow sorting by organization

### DIFF
--- a/app/scripts/app.js
+++ b/app/scripts/app.js
@@ -43,15 +43,18 @@ app.config(function($locationProvider, $stateProvider, $urlRouterProvider, confi
             },
             resolve: {
                 tests: function(AcceptanceTestsService, UserService, $stateParams) {
-                    var isAnonymous = !UserService.user();
                     var filters = {
                         keyword: $stateParams.keyword,
                         organization: $stateParams.organization,
                         state: $stateParams.state,
                         status: $stateParams.status
                     };
-
-                    return AcceptanceTestsService.get(filters, isAnonymous);
+                    return UserService.getUserPromise().then(function(result) {
+                        // Don't use anonymous mode when the user is logged (to display test creators, etc.)
+                        return AcceptanceTestsService.get(filters, false);
+                    }).catch(function() {
+                        return AcceptanceTestsService.get(filters, true);
+                    });
                 }
             }
         })

--- a/app/scripts/services/user.js
+++ b/app/scripts/services/user.js
@@ -9,11 +9,15 @@ angular.module('ludwig').factory('UserService', function($http, $rootScope, conf
         },
 
         retrieveUserAsync: function() {
-            return $http.get(config.baseApiPath + '/profile').then(function(result) {
+            return  this.getUserPromise().then(function(result) {
                 user = result.data;
                 $rootScope.$broadcast('userLoggedIn', user);
                 return result.data;
             });
+        },
+
+        getUserPromise: function() {
+            return $http.get(config.baseApiPath + '/profile');
         },
 
         login: function(email, password) {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ludwig-ui",
   "description": "Web GUI for Ludwig, the collaborative testing tool",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "license": "AGPL-3.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
We were loading the tests before checking whether the user was logged in or not. So the organisation/creator data were never loaded, as they are accessible only if logged in.

Not sure how good is this solution, not very familiar with promises.